### PR TITLE
feat: add getReference

### DIFF
--- a/utils/tags.spec.ts
+++ b/utils/tags.spec.ts
@@ -1,0 +1,109 @@
+import { expect } from '@open-wc/testing';
+
+import { getReference } from './tags.js';
+
+describe('getReference', () => {
+  it('returns null for invalid SCL tag', () => {
+    const scl = new DOMParser().parseFromString(
+      `<SCL>
+          <Header></Header>
+          <IED name="IED"></IED>
+          <DataTypeTemplates></DataTypeTemplates>
+        </SCL>`,
+      'application/xml'
+    ).documentElement;
+    expect(getReference(scl, 'SomeInvalidTag')).to.equal(null);
+  });
+
+  it('returns null for tag not included in parent element', () => {
+    const scl = new DOMParser().parseFromString(
+      `<SCL>
+          <Header></Header>
+          <IED name="IED"></IED>
+          <DataTypeTemplates></DataTypeTemplates>
+        </SCL>`,
+      'application/xml'
+    ).documentElement;
+    expect(getReference(scl, 'VoltageLevel')).to.equal(null);
+  });
+
+  it('returns null for invalid parent element', () => {
+    const scl = new DOMParser().parseFromString(
+      `SomeInvalidSCL`,
+      'application/xml'
+    ).documentElement;
+    expect(getReference(scl, 'Bay')).to.equal(null);
+  });
+
+  it('returns correct reference for LNode element', () => {
+    const scl = new DOMParser().parseFromString(
+      `<Bay>
+          <Private>testprivate</Private>
+          <ConductingEquipment name="QA1"></ConductingEquipment>
+        </Bay>`,
+      'application/xml'
+    ).documentElement;
+    expect(getReference(scl, 'LNode')).to.equal(
+      scl.querySelector('ConductingEquipment')
+    );
+
+    const scl2 = new DOMParser().parseFromString(
+      `<Bay>
+          <Private>testprivate</Private>
+          <PowerTransformer name="pTrans"></PowerTransformer>
+          <ConductingEquipment name="QA1"></ConductingEquipment>
+        </Bay>`,
+      'application/xml'
+    ).documentElement;
+    expect(getReference(scl2, 'LNode')).to.equal(
+      scl2.querySelector('PowerTransformer')
+    );
+  });
+
+  it('returns correct reference for Substation element', () => {
+    const scl = new DOMParser().parseFromString(
+      `<SCL>
+          <Header></Header>
+          <IED name="IED"></IED>
+          <DataTypeTemplates></DataTypeTemplates>
+        </SCL>`,
+      'application/xml'
+    ).documentElement;
+    expect(getReference(scl, 'Substation')).to.equal(scl.querySelector('IED'));
+  });
+
+  it('returns correct reference for VoltageLevel element', () => {
+    const scl = new DOMParser().parseFromString(
+      `<Substation>
+          <Private></Private>
+          <LNode></LNode>
+        </Substation>`,
+      'application/xml'
+    ).documentElement;
+    expect(getReference(scl, 'VoltageLevel')).to.be.null;
+  });
+
+  it('returns correct reference for Bay element', () => {
+    const scl = new DOMParser().parseFromString(
+      `<VoltageLevel>
+          <Private></Private>
+          <Function></Function>
+        </VoltageLevel>`,
+      'application/xml'
+    ).documentElement;
+    expect(getReference(scl, 'Bay')).to.equal(scl.querySelector('Function'));
+  });
+
+  it('returns correct reference for ConductingEquipment element', () => {
+    const scl = new DOMParser().parseFromString(
+      `<Bay>
+          <Private></Private>
+          <ConnectivityNode></ConnectivityNode>
+        </Bay>`,
+      'application/xml'
+    ).documentElement;
+    expect(getReference(scl, 'ConductingEquipment')).to.equal(
+      scl.querySelector('ConnectivityNode')
+    );
+  });
+});

--- a/utils/tags.ts
+++ b/utils/tags.ts
@@ -845,3 +845,32 @@ export function childTags(tagName: string): string[] {
 
   return tags[tagName].children;
 }
+
+/** @returns Reference for new [[`tag`]] child within [[`parent`]]  or `null` */
+export function getReference(parent: Element, tag: string): Element | null {
+  if (!isSCLTag(tag)) return null;
+
+  const parentTag = parent.tagName;
+  const children = Array.from(parent.children);
+
+  if (
+    parentTag === 'Services' ||
+    parentTag === 'SettingGroups' ||
+    !isSCLTag(parentTag)
+  )
+    return children.find(child => child.tagName === tag) ?? null;
+
+  const sequence = tags[parentTag].children;
+  let index = sequence.findIndex(element => element === tag);
+
+  if (index < 0) return null;
+
+  let nextSibling: Element | undefined;
+  while (index < sequence.length && !nextSibling) {
+    // eslint-disable-next-line no-loop-func
+    nextSibling = children.find(child => child.tagName === sequence[index]);
+    index += 1;
+  }
+
+  return nextSibling ?? null;
+}


### PR DESCRIPTION
SCL schemas define most elements within sequences. This function helps to determine - in insert functions - where to add the new child element within an existing parent.

Closes #5 